### PR TITLE
Add support for multiple phone numbers

### DIFF
--- a/NokiaIBConverter/ContactEntry.cs
+++ b/NokiaIBConverter/ContactEntry.cs
@@ -6,6 +6,10 @@
 
         public string LastName { get; set; }
 
-        public string PhoneNumber { get; set; }
+        public string PhoneNumber[] { get; set; }
+
+        public string PhoneNumber2[] { get; set; }
+
+        public string PhoneNumber3[] { get; set; }
     }
 }

--- a/NokiaIBConverter/ContactEntry.cs
+++ b/NokiaIBConverter/ContactEntry.cs
@@ -6,10 +6,10 @@
 
         public string LastName { get; set; }
 
-        public string PhoneNumber[] { get; set; }
+        public string[] PhoneNumber { get; set; }
 
-        public string PhoneNumber2[] { get; set; }
+        public string[] PhoneNumber2 { get; set; }
 
-        public string PhoneNumber3[] { get; set; }
+        public string[] PhoneNumber3 { get; set; }
     }
 }

--- a/NokiaIBConverter/Converter.cs
+++ b/NokiaIBConverter/Converter.cs
@@ -129,7 +129,7 @@ namespace NokiaIBConverter
                 {
                     phoneNumber = "+" + phoneNumber;
                 }
-                phoneNumber = phoneNumber.Replace("A", "*");
+                phoneNumber = phoneNumber.Replace("A", "*").Replace("C", "p").Replace("B", "#");
 
                 contact.PhoneNumber = phoneNumber;
             }

--- a/NokiaIBConverter/Converter.cs
+++ b/NokiaIBConverter/Converter.cs
@@ -120,67 +120,67 @@ namespace NokiaIBConverter
 
             return contact;
         }
-    }
 
-    private static string[] PhoneNumber(int type, int offset, FileStream reader)
-    {
-        if (type == 0)
+        private static string[] PhoneNumber(int type, int offset, FileStream reader)
         {
-            string[] empty = { "", "" };
-            return empty;
+            if (type == 0)
+            {
+                string[] empty = { "", "" };
+                return empty;
+            }
+    
+            reader.Seek(offset, SeekOrigin.Current);
+            byte[] numBytes = new byte[1];
+            reader.Read(numBytes, 0, 1);
+            byte[] numType = new byte[1];
+            reader.Read(numType, 0, 1);
+            byte[] phoneBytes = new byte[numBytes[0]];
+            reader.Read(phoneBytes, 0, numBytes[0]);
+    
+            string phoneNumber = string.Empty;
+            string phoneType = string.Empty;
+    
+            if (phoneBytes.Length > 0 && phoneBytes[0] != 0x00)
+            {
+                
+                string revPhoneNumber = string.Empty;
+                for (int i = 0; i < phoneBytes.Length; i++)
+                {
+                    revPhoneNumber += phoneBytes[i].ToString("X2");
+                }
+                for (int i = 0; i < revPhoneNumber.Length; i += 2)
+                {
+                    phoneNumber += revPhoneNumber[i + 1];
+                    phoneNumber += revPhoneNumber[i];
+                }
+                if (numType[0] == 0x11)
+                {
+                    phoneNumber = "+" + phoneNumber;
+                }
+                phoneNumber = phoneNumber.Replace("A", "*").Replace("C", "p").Replace("B", "#");
+    
+                switch (type)
+                {
+                    case 1:
+                        phoneType = "CELL";
+                        break;
+                    case 2:
+                        phoneType = "HOME";
+                        break;
+                    case 3:
+                        phoneType = "WORK";
+                        break;
+                    default:
+                        phoneType = "CELL";
+                        break;
+                }
+    
+            }
+    
+            var phoneNumberOffset = numBytes[0] + 2 + offset;
+            reader.Seek(-phoneNumberOffset, SeekOrigin.Current);
+            string[] number = { phoneType, phoneNumber };
+            return number;
         }
-
-        reader.Seek(offset, SeekOrigin.Current);
-        byte[] numBytes = new byte[1];
-        reader.Read(numBytes, 0, 1);
-        byte[] numType = new byte[1];
-        reader.Read(numType, 0, 1);
-        byte[] phoneBytes = new byte[numBytes[0]];
-        reader.Read(phoneBytes, 0, numBytes[0]);
-
-        string phoneNumber = string.Empty;
-        string phoneType = string.Empty;
-
-        if (phoneBytes.Length > 0 && phoneBytes[0] != 0x00)
-        {
-            
-            string revPhoneNumber = string.Empty;
-            for (int i = 0; i < phoneBytes.Length; i++)
-            {
-                revPhoneNumber += phoneBytes[i].ToString("X2");
-            }
-            for (int i = 0; i < revPhoneNumber.Length; i += 2)
-            {
-                phoneNumber += revPhoneNumber[i + 1];
-                phoneNumber += revPhoneNumber[i];
-            }
-            if (numType[0] == 0x11)
-            {
-                phoneNumber = "+" + phoneNumber;
-            }
-            phoneNumber = phoneNumber.Replace("A", "*").Replace("C", "p").Replace("B", "#");
-
-            switch (type)
-            {
-                case 1:
-                    phoneType = "CELL";
-                    break;
-                case 2:
-                    phoneType = "HOME";
-                    break;
-                case 3:
-                    phoneType = "WORK";
-                    break;
-                default:
-                    phoneType = "CELL";
-                    break;
-            }
-
-        }
-
-        var phoneNumberOffset = numBytes[0] + 2 + offset;
-        reader.Seek(-phoneNumberOffset, SeekOrigin.Current);
-        string[] number = { phoneType, phoneNumber };
-        return number;
     }
 }

--- a/NokiaIBConverter/Converter.cs
+++ b/NokiaIBConverter/Converter.cs
@@ -103,41 +103,84 @@ namespace NokiaIBConverter
             var lNameRevOffset = (lNameLength * blockSize) + blockSize + 0xB4;
             reader.Seek(-lNameRevOffset, SeekOrigin.Current);
 
-            //Find phone number
-            reader.Seek(0x1E, SeekOrigin.Current);
-            byte[] numBytes = new byte[1];
-            reader.Read(numBytes, 0, 1);
-            byte[] numType = new byte[1];
-            reader.Read(numType, 0, 1);
-            byte[] phoneBytes = new byte[numBytes[0]];
-            reader.Read(phoneBytes, 0, numBytes[0]);
+            //Find phone numbers
+            reader.Seek(0x1B, SeekOrigin.Current);
+            byte[] phoneOneType = new byte[1];
+            reader.Read(phoneOneType, 0, 1);
+            byte[] phoneTwoType = new byte[1];
+            reader.Read(phoneTwoType, 0, 1);
+            byte[] phoneThreeType = new byte[1];
+            reader.Read(phoneThreeType, 0, 1);
+            var typeOffset = 3 + 0x1B;
+            reader.Seek(-typeOffset, SeekOrigin.Current);
 
-            if (phoneBytes.Length > 0 && phoneBytes[0] != 0x00)
-            {
-                string phoneNumber = string.Empty;
-                string revPhoneNumber = string.Empty;
-                for (int i = 0; i < phoneBytes.Length; i++)
-                {
-                    revPhoneNumber += phoneBytes[i].ToString("X2");
-                }
-                for (int i = 0; i < revPhoneNumber.Length; i += blockSize)
-                {
-                    phoneNumber += revPhoneNumber[i + 1];
-                    phoneNumber += revPhoneNumber[i];
-                }
-                if (numType[0] == 0x11)
-                {
-                    phoneNumber = "+" + phoneNumber;
-                }
-                phoneNumber = phoneNumber.Replace("A", "*").Replace("C", "p").Replace("B", "#");
-
-                contact.PhoneNumber = phoneNumber;
-            }
-
-            var phoneNumberOffset = numBytes[0] + 0x20;
-            reader.Seek(-phoneNumberOffset, SeekOrigin.Current);
+            contact.PhoneNumber = PhoneNumber(phoneOneType[0], 0x1E, reader);
+            contact.PhoneNumber2 = PhoneNumber(phoneTwoType[0], 0x34, reader);
+            contact.PhoneNumber3 = PhoneNumber(phoneThreeType[0], 0x4A, reader);
 
             return contact;
         }
+    }
+
+    private static string[] PhoneNumber(int type, int offset, FileStream reader)
+    {
+        if (type == 0)
+        {
+            string[] empty = { "", "" };
+            return empty;
+        }
+
+        reader.Seek(offset, SeekOrigin.Current);
+        byte[] numBytes = new byte[1];
+        reader.Read(numBytes, 0, 1);
+        byte[] numType = new byte[1];
+        reader.Read(numType, 0, 1);
+        byte[] phoneBytes = new byte[numBytes[0]];
+        reader.Read(phoneBytes, 0, numBytes[0]);
+
+        string phoneNumber = string.Empty;
+        string phoneType = string.Empty;
+
+        if (phoneBytes.Length > 0 && phoneBytes[0] != 0x00)
+        {
+            
+            string revPhoneNumber = string.Empty;
+            for (int i = 0; i < phoneBytes.Length; i++)
+            {
+                revPhoneNumber += phoneBytes[i].ToString("X2");
+            }
+            for (int i = 0; i < revPhoneNumber.Length; i += 2)
+            {
+                phoneNumber += revPhoneNumber[i + 1];
+                phoneNumber += revPhoneNumber[i];
+            }
+            if (numType[0] == 0x11)
+            {
+                phoneNumber = "+" + phoneNumber;
+            }
+            phoneNumber = phoneNumber.Replace("A", "*").Replace("C", "p").Replace("B", "#");
+
+            switch (type)
+            {
+                case 1:
+                    phoneType = "CELL";
+                    break;
+                case 2:
+                    phoneType = "HOME";
+                    break;
+                case 3:
+                    phoneType = "WORK";
+                    break;
+                default:
+                    phoneType = "CELL";
+                    break;
+            }
+
+        }
+
+        var phoneNumberOffset = numBytes[0] + 2 + offset;
+        reader.Seek(-phoneNumberOffset, SeekOrigin.Current);
+        string[] number = { phoneType, phoneNumber };
+        return number;
     }
 }

--- a/NokiaIBConverter/VcfWriter.cs
+++ b/NokiaIBConverter/VcfWriter.cs
@@ -20,7 +20,7 @@ namespace NokiaIBConverter
         {
             _contactsFolderPath = contactsFolderPath;
             CreateTargetFolder(contactsFolderPath);
-            _streamWriter = new StreamWriter($"{contactsFolderPath}\\{vcfFileName}", false, Encoding.UTF8);
+            _streamWriter = new StreamWriter($"{contactsFolderPath}\\{vcfFileName}", false, UTF8Encoding(false));
         }
 
         public void Write(ContactEntry contact)
@@ -36,7 +36,7 @@ namespace NokiaIBConverter
             if (streamWriter == null)
             {
                 var uniqueId = $"{_contactsFolderPath}\\{CleanString(firstName + lastName)}.vcf";
-                streamWriter = new StreamWriter(uniqueId, false, Encoding.UTF8);
+                streamWriter = new StreamWriter(uniqueId, false, UTF8Encoding(false));
                 localWriterScope = new StreamWriterScope(streamWriter);
             }
             

--- a/NokiaIBConverter/VcfWriter.cs
+++ b/NokiaIBConverter/VcfWriter.cs
@@ -20,7 +20,8 @@ namespace NokiaIBConverter
         {
             _contactsFolderPath = contactsFolderPath;
             CreateTargetFolder(contactsFolderPath);
-            _streamWriter = new StreamWriter($"{contactsFolderPath}\\{vcfFileName}", false, UTF8Encoding(false));
+            Encoding utf8WithoutBom = new UTF8Encoding(false);
+            _streamWriter = new StreamWriter($"{contactsFolderPath}\\{vcfFileName}", false, utf8WithoutBom);
         }
 
         public void Write(ContactEntry contact)
@@ -36,7 +37,8 @@ namespace NokiaIBConverter
             if (streamWriter == null)
             {
                 var uniqueId = $"{_contactsFolderPath}\\{CleanString(firstName + lastName)}.vcf";
-                streamWriter = new StreamWriter(uniqueId, false, UTF8Encoding(false));
+                Encoding utf8WithoutBom = new UTF8Encoding(false);
+                streamWriter = new StreamWriter(uniqueId, false, utf8WithoutBom);
                 localWriterScope = new StreamWriterScope(streamWriter);
             }
             

--- a/NokiaIBConverter/VcfWriter.cs
+++ b/NokiaIBConverter/VcfWriter.cs
@@ -29,7 +29,9 @@ namespace NokiaIBConverter
             StreamWriter streamWriter = _streamWriter;
             var firstName = contact.FirstName ?? string.Empty;
             var lastName = contact.LastName ?? string.Empty;
-            var phone = contact.PhoneNumber ?? string.Empty;
+            var phone = contact.PhoneNumber;
+            var phone2 = contact.PhoneNumber2;
+            var phone3 = contact.PhoneNumber3;
             
             if (streamWriter == null)
             {
@@ -42,7 +44,18 @@ namespace NokiaIBConverter
             streamWriter.WriteLine("VERSION:2.1");
             streamWriter.WriteLine($"FN;ENCODING=QUOTED-PRINTABLE;CHARSET=utf-8:{firstName} {lastName}");
             streamWriter.WriteLine($"N;ENCODING=QUOTED-PRINTABLE;CHARSET=utf-8:{firstName};{lastName}");
-            streamWriter.WriteLine($"TEL;CELL:{phone.Replace("F", string.Empty)}");
+            if (phone[1] != string.Empty)
+            {
+                streamWriter.WriteLine($"TEL;{phone[0]}:{phone[1].Replace("F", string.Empty)}");
+            }
+            if (phone2[1] != string.Empty)
+            {
+                streamWriter.WriteLine($"TEL;{phone2[0]}:{phone2[1].Replace("F", string.Empty)}");
+            }
+            if (phone3[1] != string.Empty)
+            {
+                streamWriter.WriteLine($"TEL;{phone3[0]}:{phone3[1].Replace("F", string.Empty)}");
+            }
             streamWriter.WriteLine("END:VCARD");
             localWriterScope?.Dispose();
         }


### PR DESCRIPTION
After having a go at decoding the phonebook.ib file, I suggest a few improvements

1.  Support for Pause (p) and Hash (#) in phone numbers
2. Multiple phone numbers
    According to the backup I was working on, a contact can contain up to 3 numbers
    First one at 0x1E, 2nd at 0x34 and third at 0x4A
3. Phone number types
    The bytes 0x1B, 0x1C & 0x1C determine the types of phone numbers 1 -3 respectively
    where 1 = CELL, 2 = HOME, 3 = WORK